### PR TITLE
Keep a running clone visible and cancellable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ lives in the git log and the GitHub release notes.
 
 ### Fixed
 
+- A running clone is no longer lost when its dialog is dismissed. Clone
+  progress and a Cancel button now live in a strip below the repo tabs, so
+  closing the "+" menu or the Repositories panel mid-clone keeps the clone
+  visible and cancellable. The clone's outcome is reported as a toast
+  (previously a clone that failed after the dialog closed failed silently),
+  and the "+" menu no longer pins itself open while cloning.
 - Repositories with very large working trees (e.g. a home directory opened as
   a repo) no longer hold up startup: the filesystem watcher now attaches in
   the background instead of blocking the "restoring repositories…" splash,

--- a/src/panels/AppLayout.tsx
+++ b/src/panels/AppLayout.tsx
@@ -16,6 +16,7 @@ import { useAutoFetch } from "../lib/useAutoFetch";
 import { useStartupUpdateCheck } from "../lib/useStartupUpdateCheck";
 import type { RegionPlacement } from "../lib/types";
 import { GlobalDock } from "./GlobalDock";
+import { CloneStrip } from "./CloneStrip";
 import { OpStateStrip } from "./OpStateStrip";
 import { NoRepoHint } from "./NoRepoHint";
 import { LfsWarningBanner } from "./LfsWarningBanner";
@@ -354,6 +355,7 @@ export function AppLayout() {
           </div>
           <div style={{ flex: 1, minWidth: collapsed ? 0 : MIN_WIDTH, display: "flex", flexDirection: "column" }}>
             <RepoTabBar />
+            <CloneStrip />
             <OpStateStrip />
             <LfsWarningBanner />
             <div className="legit-repo-region" style={{ flex: 1, minHeight: 0, position: "relative" }}>
@@ -389,6 +391,7 @@ export function AppLayout() {
         {dividerControls}
       </div>
       <RepoTabBar />
+      <CloneStrip />
       <OpStateStrip />
       <LfsWarningBanner />
       <div className="legit-repo-region" style={{ flex: 1, minHeight: 0, position: "relative" }}>

--- a/src/panels/CloneStrip.test.tsx
+++ b/src/panels/CloneStrip.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+//
+// Regression test for the orphaned clone: the clone dialog used to hold the
+// op id in a component ref, so dismissing it left the clone running with no
+// progress readout and no way to cancel it. The strip is app chrome fed by
+// `useCloneStore`, so it survives the form that started the clone.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const cancelClone = vi.fn((_opId: string) => Promise.resolve(true));
+vi.mock("../lib/commands", () => ({ cancelClone: (id: string) => cancelClone(id) }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn(() => Promise.resolve(null)) }));
+
+import { CloneStrip } from "./CloneStrip";
+import { CloneForm } from "./Repositories/forms";
+import { useCloneStore } from "../store/clone";
+import { useRemoteProgressStore } from "../store/remoteProgress";
+import { useRepoStore } from "../store/repos";
+import { useSettingsStore } from "../store/settings";
+
+/** A clone that stays in flight until the returned resolver is called. */
+function pendingClone() {
+  let resolve!: (v: unknown) => void;
+  const promise = new Promise((r) => (resolve = r));
+  useRepoStore.setState({ cloneRepo: vi.fn(() => promise) } as never);
+  return resolve;
+}
+
+describe("CloneStrip", () => {
+  let container: HTMLElement;
+  let root: Root;
+
+  const rows = () => Array.from(container.querySelectorAll('[data-testid="clone-strip-row"]'));
+  const rowText = (i = 0) => rows()[i].textContent ?? "";
+  const cancelButton = (i = 0) =>
+    Array.from(rows()[i].querySelectorAll("button")).find((b) =>
+      (b.textContent ?? "").includes("Cancel"),
+    )!;
+
+  beforeEach(() => {
+    cancelClone.mockClear();
+    useCloneStore.setState({ jobs: {}, completedCount: 0 });
+    useRemoteProgressStore.setState({ byOp: {} });
+    document.body.innerHTML = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+  });
+
+  it("renders nothing while no clone is running", () => {
+    act(() => root.render(<CloneStrip />));
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows one row per clone, with the live meter once git reports one", () => {
+    pendingClone();
+    act(() => root.render(<CloneStrip />));
+
+    let opId = "";
+    act(() => {
+      opId = useCloneStore.getState().start({
+        url: "https://example.com/legit.git",
+        parentDir: "/src",
+        name: "legit",
+        profileId: null,
+        options: {},
+      });
+    });
+
+    expect(rows()).toHaveLength(1);
+    // No meter yet: git has not printed its first progress line.
+    expect(rowText()).toContain("Cloning legit");
+    expect(rowText()).toContain("starting…");
+
+    act(() => {
+      useRemoteProgressStore.getState().report(opId, { phase: "Receiving objects", percent: 42 });
+    });
+    expect(rowText()).toContain("Receiving objects 42%");
+
+    act(() => {
+      useCloneStore.getState().start({
+        url: "https://example.com/other.git",
+        parentDir: "/src",
+        name: "other",
+        profileId: null,
+        options: {},
+      });
+    });
+    expect(rows()).toHaveLength(2);
+  });
+
+  it("cancels the clone and reports that it is cancelling", () => {
+    pendingClone();
+    act(() => root.render(<CloneStrip />));
+    let opId = "";
+    act(() => {
+      opId = useCloneStore.getState().start({
+        url: "https://example.com/legit.git",
+        parentDir: "/src",
+        name: "legit",
+        profileId: null,
+        options: {},
+      });
+    });
+
+    act(() => cancelButton().click());
+
+    expect(cancelClone).toHaveBeenCalledWith(opId);
+    expect(rowText()).toContain("cancelling…");
+    // The kill is not instant - a second click must not fire again.
+    expect(cancelButton().disabled).toBe(true);
+  });
+
+  it("keeps the clone visible and cancellable after its dialog is dismissed", () => {
+    pendingClone();
+    useSettingsStore.setState({ settings: null } as never);
+
+    // Two roots: the dismissable dialog host, and the app-chrome strip.
+    const formContainer = document.createElement("div");
+    document.body.appendChild(formContainer);
+    const formRoot = createRoot(formContainer);
+
+    act(() => root.render(<CloneStrip />));
+    act(() =>
+      formRoot.render(
+        <CloneForm
+          profiles={[]}
+          onCancel={() => {}}
+          onError={() => {}}
+          onClone={(url, parentDir, name, profileId, options) => {
+            useCloneStore.getState().start({ url, parentDir, name, profileId, options });
+          }}
+        />,
+      ),
+    );
+
+    const input = (label: string) =>
+      Array.from(formContainer.querySelectorAll("label")).find((l) =>
+        (l.textContent ?? "").startsWith(label),
+      )!.querySelector("input")!;
+
+    const setValue = (el: HTMLInputElement, value: string) => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    };
+
+    act(() => setValue(input("URL"), "https://example.com/legit.git"));
+    act(() => setValue(input("Into folder"), "/src"));
+    expect(input("Folder name").value).toBe("legit");
+
+    const cloneBtn = Array.from(formContainer.querySelectorAll("button")).find(
+      (b) => (b.textContent ?? "").trim() === "Clone",
+    )!;
+    act(() => cloneBtn.click());
+
+    // The user dismisses the dialog while the clone runs. Pre-fix this
+    // orphaned the op id; now the strip still owns it.
+    act(() => formRoot.unmount());
+    formContainer.remove();
+
+    expect(rows()).toHaveLength(1);
+    expect(rowText()).toContain("Cloning legit");
+
+    const opId = Object.keys(useCloneStore.getState().jobs)[0];
+    act(() => {
+      useRemoteProgressStore.getState().report(opId, { phase: "Receiving objects", percent: 8 });
+    });
+    expect(rowText()).toContain("Receiving objects 8%");
+
+    act(() => cancelButton().click());
+    expect(cancelClone).toHaveBeenCalledWith(opId);
+  });
+});

--- a/src/panels/CloneStrip.tsx
+++ b/src/panels/CloneStrip.tsx
@@ -1,0 +1,87 @@
+import { useCloneStore } from "../store/clone";
+import type { CloneJob } from "../store/clone";
+import { useRemoteProgressStore } from "../store/remoteProgress";
+import { ToolbarButton } from "./shared/ToolbarButton";
+
+// The strip's ghost buttons sit on banner-op-bg, not a panel surface, so
+// their text and border must follow the banner's own foreground token.
+const BANNER_BUTTON_STYLE: React.CSSProperties = {
+  color: "var(--banner-op-fg)",
+  borderColor: "var(--banner-op-fg)",
+};
+
+/**
+ * App-chrome surface for running clones: rendered by AppLayout above the
+ * repo-scoped OpStateStrip, so a clone stays visible and cancellable after
+ * its dialog is dismissed — the form owns no part of the operation.
+ *
+ * Not repo-scoped (a clone has no repo yet), so it shows with no repo open
+ * too. Renders nothing while no clone is running.
+ */
+export function CloneStrip() {
+  const jobs = useCloneStore((s) => s.jobs);
+  const ids = Object.keys(jobs);
+  if (ids.length === 0) return null;
+  return (
+    <div data-testid="clone-strip">
+      {ids
+        .map((id) => jobs[id])
+        .sort((a, b) => a.startedAt - b.startedAt)
+        .map((job) => (
+          <CloneRow key={job.opId} job={job} />
+        ))}
+    </div>
+  );
+}
+
+function CloneRow({ job }: { job: CloneJob }) {
+  const cancel = useCloneStore((s) => s.cancel);
+  // Live transfer progress (legit://remote-progress, keyed by our opId). It
+  // only exists once git has printed its first meter line.
+  const progress = useRemoteProgressStore((s) => s.byOp[job.opId]);
+
+  const status = job.cancelling
+    ? "cancelling…"
+    : progress
+      ? `${progress.phase}${progress.percent != null ? ` ${progress.percent}%` : "…"}`
+      : "starting…";
+
+  return (
+    <div
+      data-testid="clone-strip-row"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "4px 8px",
+        background: "var(--banner-op-bg)",
+        color: "var(--banner-op-fg)",
+        fontSize: "var(--fz-sm)",
+        // Hairline: separates this row from a row or banner stacked below it.
+        borderBottom: "1px solid var(--panel-border)",
+      }}
+    >
+      <span className="legit-spinner" aria-hidden="true" />
+      <span
+        title={`${job.url} → ${job.parentDir}`}
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          minWidth: 0,
+        }}
+      >
+        Cloning {job.name} · {status}
+      </span>
+      <span style={{ display: "flex", gap: 4, marginLeft: "auto" }}>
+        <ToolbarButton
+          label="Cancel"
+          title="Stop the clone and remove its partial files"
+          disabled={job.cancelling}
+          onClick={() => cancel(job.opId)}
+          style={BANNER_BUTTON_STYLE}
+        />
+      </span>
+    </div>
+  );
+}

--- a/src/panels/RepoAddMenu.tsx
+++ b/src/panels/RepoAddMenu.tsx
@@ -4,6 +4,7 @@ import { recentRepos } from "../lib/commands";
 import { parseLocator } from "../lib/locator";
 import { formatAppError } from "../lib/types";
 import { useGitProfiles } from "../lib/useGitProfiles";
+import { useCloneStore } from "../store/clone";
 import { useRepoStore } from "../store/repos";
 import { notify } from "../store/notifications";
 import { SectionLabel } from "./Commits/menu/primitives";
@@ -20,13 +21,13 @@ type Mode = "menu" | "clone" | "init";
  * plus the most recent repos), so cloning or initializing never requires the
  * Repositories panel. The forms are the shared ones from `Repositories/forms`.
  *
- * While a clone is running the popover pins itself open — outside clicks and
- * Escape are ignored — because dismissing it would orphan the progress meter
- * and the cancel button. Only "Cancel clone" (or completion) releases it.
+ * Submitting a clone closes the popover at once: the clone lives in
+ * `useCloneStore` and is shown (and cancelled) from the app-chrome clone
+ * strip, so nothing here has to be pinned open to keep it reachable.
  */
 export function RepoAddMenu() {
   const openRepo = useRepoStore((s) => s.openRepo);
-  const cloneRepo = useRepoStore((s) => s.cloneRepo);
+  const startClone = useCloneStore((s) => s.start);
   const initRepo = useRepoStore((s) => s.initRepo);
 
   const [open, setOpen] = useState(false);
@@ -35,9 +36,6 @@ export function RepoAddMenu() {
   const { data: profiles = [], refetch: refetchProfiles } = useGitProfiles();
   const [error, setError] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
-  // Pin while a clone is in flight; a ref so the document listener sees the
-  // current value without re-registering.
-  const cloneBusyRef = useRef(false);
 
   const openRepoIds = useRepoStore((s) => s.openRepos.map((r) => r.id).join("\0"));
 
@@ -56,16 +54,15 @@ export function RepoAddMenu() {
   };
 
   // Dismiss on outside mousedown + Escape (capture phase, like every other
-  // menu) — unless a clone is running.
+  // menu).
   useEffect(() => {
     if (!open) return;
     const controller = new AbortController();
     const onDown = (e: MouseEvent) => {
-      if (cloneBusyRef.current) return;
       if (ref.current && !ref.current.contains(e.target as Node)) close();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !cloneBusyRef.current) {
+      if (e.key === "Escape") {
         // Consumed: closing the menu must not leak to other Escape listeners
         // (e.g. exiting a maximized panel).
         e.stopPropagation();
@@ -164,11 +161,8 @@ export function RepoAddMenu() {
               profiles={profiles}
               onCancel={() => setMode("menu")}
               onError={setError}
-              onBusyChange={(busy) => {
-                cloneBusyRef.current = busy;
-              }}
-              onClone={async (url, parentDir, name, profileId, opId, options) => {
-                await cloneRepo(url, parentDir, name, profileId, opId, options);
+              onClone={(url, parentDir, name, profileId, options) => {
+                startClone({ url, parentDir, name, profileId, options });
                 close();
               }}
             />

--- a/src/panels/Repositories/RepositoriesPanel.tsx
+++ b/src/panels/Repositories/RepositoriesPanel.tsx
@@ -4,6 +4,7 @@ import { recentRepos } from "../../lib/commands";
 import { parseLocator } from "../../lib/locator";
 import { formatAppError } from "../../lib/types";
 import { useGitProfiles } from "../../lib/useGitProfiles";
+import { useCloneStore } from "../../store/clone";
 import { useRepoStore } from "../../store/repos";
 import { notify } from "../../store/notifications";
 import { Button } from "../shared/buttons";
@@ -18,7 +19,10 @@ export function RepositoriesPanel() {
   const activeRepoId = useRepoStore((s) => s.activeRepoId);
   const openRepo = useRepoStore((s) => s.openRepo);
   const initRepo = useRepoStore((s) => s.initRepo);
-  const cloneRepo = useRepoStore((s) => s.cloneRepo);
+  const startClone = useCloneStore((s) => s.start);
+  // A clone outlives this panel now, so its completion (not the submit) is
+  // what makes the recents list stale.
+  const clonesCompleted = useCloneStore((s) => s.completedCount);
   const closeRepo = useRepoStore((s) => s.closeRepo);
   const setActive = useRepoStore((s) => s.setActive);
   const refresh = useRepoStore((s) => s.refresh);
@@ -32,7 +36,7 @@ export function RepositoriesPanel() {
   useEffect(() => {
     if (!initialized) refresh();
     recentRepos().then(setRecents).catch(console.warn);
-  }, [initialized, refresh]);
+  }, [initialized, refresh, clonesCompleted]);
 
   const refreshRecents = () => recentRepos().then(setRecents).catch(console.warn);
 
@@ -74,10 +78,9 @@ export function RepositoriesPanel() {
             profiles={profiles}
             onCancel={() => setMode("none")}
             onError={setError}
-            onClone={async (url, parentDir, name, profileId, opId, options) => {
-              await cloneRepo(url, parentDir, name, profileId, opId, options);
+            onClone={(url, parentDir, name, profileId, options) => {
+              startClone({ url, parentDir, name, profileId, options });
               setMode("none");
-              refreshRecents();
             }}
           />
           </div>

--- a/src/panels/Repositories/forms.tsx
+++ b/src/panels/Repositories/forms.tsx
@@ -2,12 +2,10 @@
 // strip's "+" menu (one implementation — the two surfaces must not drift).
 
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { useEffect, useRef, useState } from "react";
-import { cancelClone } from "../../lib/commands";
+import { useState } from "react";
 import type { CloneOptions, InitOptions } from "../../lib/commands";
 import type { GitProfile } from "../../lib/types";
-import { cloneCancelCleanupFailure, formatAppError, gitErrorKind } from "../../lib/types";
-import { useRemoteProgressStore } from "../../store/remoteProgress";
+import { formatAppError } from "../../lib/types";
 import { useSettingsStore } from "../../store/settings";
 import { Button } from "../shared/buttons";
 import { useDelayedBusy } from "../shared/useDelayedBusy";
@@ -19,12 +17,17 @@ export function deriveName(url: string): string {
   return seg.replace(/\.git$/i, "");
 }
 
+/**
+ * The clone form owns NO part of the running clone: `onClone` hands the
+ * request to `useCloneStore`, which keeps the op id alive in app chrome (the
+ * clone strip) with the progress meter and the cancel button. That is what
+ * makes dismissing this form safe — it used to orphan the clone.
+ */
 export function CloneForm({
   profiles,
   onClone,
   onCancel,
   onError,
-  onBusyChange,
 }: {
   profiles: GitProfile[];
   onClone: (
@@ -32,15 +35,10 @@ export function CloneForm({
     parentDir: string,
     name: string,
     profileId: string | null,
-    opId: string,
     options: CloneOptions,
-  ) => Promise<void>;
+  ) => void;
   onCancel: () => void;
   onError: (msg: string | null) => void;
-  /** Reports the in-flight state so a floating host (the "+" popover) can pin
-   * itself open while a clone runs — a dismissed popover would orphan the
-   * progress meter and the cancel button. */
-  onBusyChange?: (busy: boolean) => void;
 }) {
   const [url, setUrl] = useState("");
   // Prefilled with the previous clone's parent - most users keep one source
@@ -54,64 +52,21 @@ export function CloneForm({
   const [depth, setDepth] = useState("");
   const [branch, setBranch] = useState("");
   const [recurseSubmodules, setRecurseSubmodules] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const opIdRef = useRef<string | null>(null);
-  const cancelRequestedRef = useRef(false);
-
-  const setBusyBoth = (b: boolean) => {
-    setBusy(b);
-    onBusyChange?.(b);
-  };
-
-  // Live clone transfer progress (legit://remote-progress, keyed by our opId).
-  const progress = useRemoteProgressStore((s) =>
-    opIdRef.current ? s.byOp[opIdRef.current] : undefined,
-  );
 
   const browse = async () => {
     const sel = await openDialog({ directory: true, multiple: false });
     if (typeof sel === "string") setParentDir(sel);
   };
 
-  const submit = async () => {
+  const submit = () => {
     if (!url.trim() || !parentDir.trim() || !name.trim()) return;
-    const opId = crypto.randomUUID();
-    opIdRef.current = opId;
-    cancelRequestedRef.current = false;
-    setBusyBoth(true);
     onError(null);
     const parsedDepth = Number.parseInt(depth, 10);
-    try {
-      await onClone(url.trim(), parentDir.trim(), name.trim(), profileId || null, opId, {
-        depth: Number.isFinite(parsedDepth) && parsedDepth > 0 ? parsedDepth : null,
-        branch: branch.trim() || null,
-        recurseSubmodules,
-      });
-    } catch (e) {
-      if (gitErrorKind(e) === "CloneCancelled") {
-        // Expected outcome of the Cancel button: stay silent - unless the
-        // backend could not remove the partial clone's files.
-        const note = cloneCancelCleanupFailure(e);
-        if (note) onError(note);
-      } else if (!cancelRequestedRef.current) {
-        onError(
-          gitErrorKind(e) === "AuthFailed"
-            ? "Authentication failed. Pick a profile with the right credentials, or fix your global git credentials."
-            : formatAppError(e),
-        );
-      }
-    } finally {
-      useRemoteProgressStore.getState().clear(opId);
-      setBusyBoth(false);
-      opIdRef.current = null;
-    }
-  };
-
-  const cancel = () => {
-    if (opIdRef.current) {
-      cancelRequestedRef.current = true;
-      void cancelClone(opIdRef.current);
-    }
+    onClone(url.trim(), parentDir.trim(), name.trim(), profileId || null, {
+      depth: Number.isFinite(parsedDepth) && parsedDepth > 0 ? parsedDepth : null,
+      branch: branch.trim() || null,
+      recurseSubmodules,
+    });
   };
 
   return (
@@ -164,24 +119,10 @@ export function CloneForm({
         Clone submodules
       </label>
       <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4 }}>
-        <Button variant="primary" disabled={busy || !url.trim() || !parentDir.trim() || !name.trim()} onClick={submit}>
-          {busy ? "Cloning…" : "Clone"}
+        <Button variant="primary" disabled={!url.trim() || !parentDir.trim() || !name.trim()} onClick={submit}>
+          Clone
         </Button>
-        {busy ? (
-          <button onClick={cancel}>Cancel clone</button>
-        ) : (
-          <button onClick={onCancel}>Close</button>
-        )}
-        {busy && <span className="legit-spinner" aria-hidden="true" />}
-        {busy && progress && (
-          <span
-            className="legit-subtle"
-            style={{ fontSize: "var(--fz-sm)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
-          >
-            {progress.phase}
-            {progress.percent != null ? ` ${progress.percent}%` : "…"}
-          </span>
-        )}
+        <button onClick={onCancel}>Close</button>
       </div>
     </FormCard>
   );

--- a/src/store/clone.test.ts
+++ b/src/store/clone.test.ts
@@ -1,0 +1,212 @@
+// Unit tests for the in-flight clone store.
+//
+// The bug this pins: the op id used to live in `CloneForm`'s ref, so
+// dismissing the clone dialog orphaned the clone — uncancellable, with no
+// progress meter and a silently swallowed outcome. The store now owns the
+// op id, so it is reachable (and cancellable) with no component mounted.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const cancelClone = vi.fn((_opId: string) => Promise.resolve(true));
+vi.mock("../lib/commands", () => ({ cancelClone: (id: string) => cancelClone(id) }));
+
+import { useCloneStore } from "./clone";
+import { useNotificationsStore } from "./notifications";
+import { useRemoteProgressStore } from "./remoteProgress";
+import { useRepoStore } from "./repos";
+
+/** A clone that never settles until the returned handle is used. */
+function deferredClone() {
+  let resolve!: (v: unknown) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const cloneRepo = vi.fn(() => promise);
+  useRepoStore.setState({ cloneRepo } as never);
+  return { resolve, reject, cloneRepo };
+}
+
+const START = {
+  url: "https://example.com/legit.git",
+  parentDir: "/src",
+  name: "legit",
+  profileId: null,
+  options: {},
+};
+
+/** Let the store's async `finally` run. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  cancelClone.mockClear();
+  useCloneStore.setState({ jobs: {}, completedCount: 0 });
+  useNotificationsStore.setState({ toasts: [] });
+  useRemoteProgressStore.setState({ byOp: {} });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("clone store job lifecycle", () => {
+  it("registers the job synchronously, so a dismissed dialog can still cancel it", async () => {
+    const { resolve } = deferredClone();
+
+    // The caller (the form) starts the clone and immediately forgets the id -
+    // exactly what happens when the dialog is dismissed.
+    useCloneStore.getState().start(START);
+
+    const ids = Object.keys(useCloneStore.getState().jobs);
+    expect(ids).toHaveLength(1);
+    const opId = ids[0];
+    expect(useCloneStore.getState().jobs[opId]).toMatchObject({
+      opId,
+      name: "legit",
+      url: START.url,
+      parentDir: "/src",
+      cancelling: false,
+    });
+
+    useCloneStore.getState().cancel(opId);
+    expect(cancelClone).toHaveBeenCalledWith(opId);
+    expect(useCloneStore.getState().jobs[opId].cancelling).toBe(true);
+
+    resolve({ id: "repo-1" });
+    await settle();
+    expect(useCloneStore.getState().jobs).toEqual({});
+  });
+
+  it("passes the store-minted op id to cloneRepo", async () => {
+    const { resolve, cloneRepo } = deferredClone();
+    const opId = useCloneStore.getState().start({ ...START, profileId: "p1" });
+
+    expect(cloneRepo).toHaveBeenCalledWith(
+      START.url,
+      "/src",
+      "legit",
+      "p1",
+      opId,
+      START.options,
+    );
+    resolve({ id: "repo-1" });
+    await settle();
+  });
+
+  it("drops the job and clears its progress meter on success", async () => {
+    const { resolve } = deferredClone();
+    const opId = useCloneStore.getState().start(START);
+    useRemoteProgressStore.getState().report(opId, { phase: "Receiving objects", percent: 42 });
+
+    resolve({ id: "repo-1" });
+    await settle();
+
+    expect(useCloneStore.getState().jobs).toEqual({});
+    expect(useRemoteProgressStore.getState().byOp[opId]).toBeUndefined();
+    expect(useCloneStore.getState().completedCount).toBe(1);
+    expect(useNotificationsStore.getState().toasts.map((t) => [t.kind, t.message])).toEqual([
+      ["success", "Cloned legit"],
+    ]);
+  });
+
+  it("drops the job and clears its progress meter on failure", async () => {
+    const { reject } = deferredClone();
+    const opId = useCloneStore.getState().start(START);
+    useRemoteProgressStore.getState().report(opId, { phase: "Receiving objects", percent: 7 });
+
+    reject("repository not found");
+    await settle();
+
+    expect(useCloneStore.getState().jobs).toEqual({});
+    expect(useRemoteProgressStore.getState().byOp[opId]).toBeUndefined();
+    expect(useCloneStore.getState().completedCount).toBe(1);
+  });
+
+  it("cancelling twice only reaches the backend once", async () => {
+    const { resolve } = deferredClone();
+    const opId = useCloneStore.getState().start(START);
+
+    useCloneStore.getState().cancel(opId);
+    useCloneStore.getState().cancel(opId);
+    expect(cancelClone).toHaveBeenCalledTimes(1);
+
+    resolve({ id: "repo-1" });
+    await settle();
+    // A cancel for a settled job is a no-op, not a stray backend call.
+    useCloneStore.getState().cancel(opId);
+    expect(cancelClone).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs two clones side by side and cancels them independently", async () => {
+    let resolveA!: (v: unknown) => void;
+    let resolveB!: (v: unknown) => void;
+    const promises = [
+      new Promise((r) => (resolveA = r)),
+      new Promise((r) => (resolveB = r)),
+    ];
+    let call = 0;
+    useRepoStore.setState({ cloneRepo: vi.fn(() => promises[call++]) } as never);
+
+    const a = useCloneStore.getState().start({ ...START, name: "alpha" });
+    const b = useCloneStore.getState().start({ ...START, name: "beta" });
+    expect(Object.keys(useCloneStore.getState().jobs)).toHaveLength(2);
+
+    useCloneStore.getState().cancel(a);
+    expect(cancelClone).toHaveBeenCalledTimes(1);
+    expect(cancelClone).toHaveBeenCalledWith(a);
+    expect(useCloneStore.getState().jobs[b].cancelling).toBe(false);
+
+    resolveA({ id: "repo-a" });
+    await settle();
+    expect(Object.keys(useCloneStore.getState().jobs)).toEqual([b]);
+
+    resolveB({ id: "repo-b" });
+    await settle();
+    expect(useCloneStore.getState().jobs).toEqual({});
+  });
+});
+
+describe("clone store outcome toasts", () => {
+  const gitError = (kind: string, details?: unknown) => ({
+    kind: "Git",
+    details: { kind, details },
+  });
+
+  const messages = () =>
+    useNotificationsStore.getState().toasts.map((t) => [t.kind, t.message]);
+
+  it("stays silent for a user cancel", async () => {
+    const { reject } = deferredClone();
+    useCloneStore.getState().start(START);
+    reject(gitError("CloneCancelled", { cleanup_failed: null }));
+    await settle();
+    expect(messages()).toEqual([]);
+  });
+
+  it("reports a cancel whose cleanup failed", async () => {
+    const { reject } = deferredClone();
+    useCloneStore.getState().start(START);
+    reject(gitError("CloneCancelled", { cleanup_failed: "could not remove /src/legit" }));
+    await settle();
+    expect(messages()).toEqual([["error", "could not remove /src/legit"]]);
+  });
+
+  it("gives the profile hint for an auth failure", async () => {
+    const { reject } = deferredClone();
+    useCloneStore.getState().start(START);
+    reject(gitError("AuthFailed"));
+    await settle();
+    expect(messages()[0][0]).toBe("error");
+    expect(messages()[0][1]).toContain("authentication failed");
+    expect(messages()[0][1]).toContain("legit");
+  });
+
+  it("surfaces any other failure - the dismissed dialog used to swallow it", async () => {
+    const { reject } = deferredClone();
+    useCloneStore.getState().start(START);
+    reject(gitError("Other", "repository not found"));
+    await settle();
+    expect(messages()[0][0]).toBe("error");
+    expect(messages()[0][1]).toContain("repository not found");
+  });
+});

--- a/src/store/clone.ts
+++ b/src/store/clone.ts
@@ -1,0 +1,108 @@
+import { create } from "zustand";
+import { cancelClone } from "../lib/commands";
+import type { CloneOptions } from "../lib/commands";
+import { cloneCancelCleanupFailure, formatAppError, gitErrorKind } from "../lib/types";
+import { notify } from "./notifications";
+import { useRemoteProgressStore } from "./remoteProgress";
+import { useRepoStore } from "./repos";
+
+/** One clone running in the backend, keyed by the op id it was started with. */
+export interface CloneJob {
+  opId: string;
+  url: string;
+  /** Target folder name — what the strip labels the job with. */
+  name: string;
+  parentDir: string;
+  startedAt: number;
+  /** A cancel was requested; the kill is not instant, so the row says so. */
+  cancelling: boolean;
+}
+
+export interface StartCloneArgs {
+  url: string;
+  parentDir: string;
+  name: string;
+  profileId: string | null;
+  options: CloneOptions;
+}
+
+/**
+ * In-flight clones. Module-level (like the console's per-repo sessions)
+ * because the op id must OUTLIVE the form that started it: a clone dialog
+ * can be dismissed while its clone runs, and that id is the only handle on
+ * the backend's cancellable `TransientOp`. The clone strip (app chrome)
+ * renders this store, so a running clone stays visible and cancellable.
+ *
+ * The outcome is reported from here as a toast: by the time a clone
+ * finishes, the form that started it is usually gone, so an inline error
+ * would be shown to nobody.
+ */
+interface CloneStore {
+  jobs: Record<string, CloneJob>;
+  /** Bumped whenever a clone settles, so surfaces caching derived data (the
+   *  Repositories panel's recents list) can refresh off it. */
+  completedCount: number;
+  /** Mint an op id, register the job, and run it. Never rejects. */
+  start: (args: StartCloneArgs) => string;
+  /** Ask the backend to kill the clone and clean up its partial target. */
+  cancel: (opId: string) => void;
+}
+
+export const useCloneStore = create<CloneStore>((set, get) => ({
+  jobs: {},
+  completedCount: 0,
+
+  start({ url, parentDir, name, profileId, options }) {
+    const opId = crypto.randomUUID();
+    // Registered BEFORE the await: the strip must be able to cancel this
+    // clone from the very first frame, even if the caller unmounts at once.
+    set((s) => ({
+      jobs: {
+        ...s.jobs,
+        [opId]: { opId, url, name, parentDir, startedAt: Date.now(), cancelling: false },
+      },
+    }));
+
+    void (async () => {
+      try {
+        await useRepoStore.getState().cloneRepo(url, parentDir, name, profileId, opId, options);
+        notify.success(`Cloned ${name}`);
+      } catch (e) {
+        if (gitErrorKind(e) === "CloneCancelled") {
+          // The expected outcome of Cancel: stay silent - unless the backend
+          // could not remove the partial clone's files.
+          const note = cloneCancelCleanupFailure(e);
+          if (note) notify.error(note);
+        } else if (gitErrorKind(e) === "AuthFailed") {
+          notify.error(
+            `Could not clone ${name}: authentication failed. Pick a profile with the right credentials, or fix your global git credentials.`,
+          );
+        } else {
+          notify.error(`Could not clone ${name}: ${formatAppError(e)}`);
+        }
+      } finally {
+        useRemoteProgressStore.getState().clear(opId);
+        set((s) => {
+          const jobs = { ...s.jobs };
+          delete jobs[opId];
+          return { jobs, completedCount: s.completedCount + 1 };
+        });
+      }
+    })();
+
+    return opId;
+  },
+
+  cancel(opId) {
+    const job = get().jobs[opId];
+    if (!job || job.cancelling) return;
+    set((s) => {
+      const current = s.jobs[opId];
+      if (!current) return s;
+      return { jobs: { ...s.jobs, [opId]: { ...current, cancelling: true } } };
+    });
+    // Fire-and-forget: the clone's own promise reports the outcome. A
+    // rejection here only means the op had already finished.
+    void cancelClone(opId).catch(() => {});
+  },
+}));

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -117,8 +117,8 @@ export const TOKEN_CONTRACT: readonly TokenDescriptor[] = [
   { name: "app.fg", group: "App", documentation: "Top-level default text." },
   { name: "accent", group: "App", documentation: "General accent: focus rings, active markers, highlighted icons." },
   { name: "accent.fg", group: "App", documentation: "Text/icons drawn on accent-coloured surfaces." },
-  { name: "banner.op.bg", group: "App", documentation: "Background of the merge/rebase-in-progress banner (app chrome, below the repo tabs)." },
-  { name: "banner.op.fg", group: "App", documentation: "Text of the merge/rebase-in-progress banner, including its buttons' text and border." },
+  { name: "banner.op.bg", group: "App", documentation: "Background of the operation-in-progress banners (merge/rebase state, running clones) in app chrome below the repo tabs." },
+  { name: "banner.op.fg", group: "App", documentation: "Text of the operation-in-progress banners, including their buttons' text and border." },
   { name: "banner.warning.bg", group: "App", documentation: "Background of app-chrome warning banners (e.g. the missing-git-lfs warning below the repo tabs)." },
   { name: "banner.warning.fg", group: "App", documentation: "Text of app-chrome warning banners, including their buttons' text and border." },
 


### PR DESCRIPTION
Stacked on #22 (`wsl-remote-repos`).

The clone's op id lived in `CloneForm`'s ref, so dismissing the dialog orphaned the clone: no progress readout, no way to cancel, and the outcome went nowhere — a clone that failed after dismissal failed silently. The `"+"` popover pinned itself open to compensate, but clicking `"+"` itself dismissed it anyway, and the Repositories panel had no mitigation at all.

The backend was already fine (`repo_clone` registers a cancellable `TransientOp`, `cancel_clone` kills it and cleans up); this is frontend wiring only.

- `src/store/clone.ts` — module-level registry of in-flight clones keyed by op id, registered before the await, outcome reported as a toast
- `src/panels/CloneStrip.tsx` — app-chrome strip below the repo tabs (sibling of `OpStateStrip`, reuses the `banner.op.*` tokens), one row per clone with the live meter and Cancel
- `CloneForm` owns no part of the operation; the `"+"` pin is gone
- Concurrent clones work, matching the backend

## Tests

`src/store/clone.test.ts` and `src/panels/CloneStrip.test.tsx`. The last case mounts the form, submits, **unmounts it**, and asserts the strip still shows the meter and its Cancel still reaches `cancel_clone`.

Not manually run against the app (Windows target, no build here) — worth a pass on cancel-after-dismiss and the partial-directory cleanup.
